### PR TITLE
Allows specifying decode strategy; support Slice / Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,17 @@ func main() {
 ```
 
 
-This library uses runtime reflection just like `encoding/json`. Most programs won't have more than a handful of config objects, so the slowness typically associated with reflection is negligible here. 
+This library uses runtime reflection just like `encoding/json`. Most programs won't have more than a handful of config objects, so the slowness typically associated with reflection is negligible here.
 
 ### Supported types
 
-Four types are currently supported: 
+Four types are currently supported:
 
 * `string` - defaults to `""`
 * `int` - defaults to `0`
 * `bool` - defaults to `false`
-* `float64` - defaults to `0.0` 
+* `float64` - defaults to `0.0`
+* `time.Duration` - defaults to `0`
 
 Support for custom types via interfaces will likely make an an appearance at a later date.
 
@@ -85,7 +86,7 @@ type Config struct {
 
 #### `default`
 
-If specified, the default will be used if no environment variable is found matching the key. Default values must be castable to the associated struct field type, otherwise an error is returned. 
+If specified, the default will be used if no environment variable is found matching the key. Default values must be castable to the associated struct field type, otherwise an error is returned.
 
 ```go
 // Look for a variable `ENABLED` or otherwise default to true
@@ -108,7 +109,7 @@ config := &Config{}
 fmt.Println(config.Name) // prints "Inigo"
 ```
 
-#### `options` 
+#### `options`
 
 Options ensure that an environment variable is in a set of possible valid values. If it is not, an error is returned.
 

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,20 @@
+package env
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDuration(t *testing.T) {
+	var cfg = struct {
+		Duration time.Duration `env:"key=DURATION default=5s"`
+	}{}
+
+	if err := Process(&cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Duration != time.Second*5 {
+		t.Fatalf("%v != %f ", cfg.Duration, time.Second*5)
+	}
+}

--- a/var.go
+++ b/var.go
@@ -187,16 +187,16 @@ func (v *Var) Parse(field reflect.StructField) error {
 }
 
 func convertYaml(t reflect.Type, value string) (reflect.Value, error) {
-    var a []interface{}
+    a := reflect.New(t)
 
-    err := yaml.Unmarshal([]byte(value), &a)
+    err := yaml.Unmarshal([]byte(value), a.Interface())
 
     if err != nil {
         fmt.Print(err)
         return reflect.ValueOf(nil), conversionError(value, `yaml conversion error of ` + t.Kind().String())
     }
 
-    return reflect.ValueOf(a), nil
+    return a.Elem(), nil
 }
 
 // Convert a string into the specified type. Return the type's zero value


### PR DESCRIPTION
Added tag for specifying which decode strategy to use for values.  This ultimately allows defining values with YAML syntax and having them decoded into Slice and Map.  

Tag is of the the form `decode=<value>`

Support values are:
- type
- kind
- yaml

YAML was chosen because it is a superset of JSON and thus both will parse with the YAML parser.  Additionally YAML does not require the explicit quotation of keys and is simpler to write inline strings with.   Both represent probably the best ways to define a list / map with inline strings.  YAML is not included in the golang:encode package, but the go-yaml project is heavily supported and used.

By default / omission, the Type strategy will be used and then Kind for fallback if that fails.  This allows lazy defining the tags and leaving the decode strategy off and if there is a Type defined for decoding it will use it, else use the Kind of the var.   

Slices and Maps have been added to the Kind decode strategy.  They use their own function which then calls the YAML parse. 

Each decoding strategy uses its own function.  This keeps each to their single responsibility and eliminates the ambiguity of using multiple decision values in a conversion (mixing Kind and Type).
